### PR TITLE
Replace restkit with requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,9 @@
-restkit
+certifi==2017.7.27.1
+chardet==3.0.4
+http-parser==0.8.3
+idna==2.6
+nose==1.3.7
+poeditor==1.0.4
+requests==2.18.4
+socketpool==0.5.3
+urllib3==1.22

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from pip.download import PipSession
+from pip.req import parse_requirements
 from setuptools import setup, find_packages
+
 import poeditor
 
+
+install_requires = []
+dependency_links = []
+
+# Inject requirements from requirements.txt into setup.py
+filename = 'requirements.txt'
+requirements_file = parse_requirements(filename, session=PipSession())
+for req in requirements_file:
+    install_requires.append(str(req.req))
+    if req.link:
+        dependency_links.append(str(req.link))
 
 setup(
     name='poeditor',
@@ -26,7 +40,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         "Topic :: Software Development :: Localization",
     ],
-    install_requires=['restkit'],
+    install_requires=install_requires,
+    dependency_links=dependency_links,
     license='MIT',
     test_suite="nose.collector",
 )


### PR DESCRIPTION
Our translations project requires that it can be used with both python2
and python3. For doing the actual calls to the poeditor API, this
library relies on restkit, which does not seem to be maintained anymore.

Therefore, I replaced all restkit-related code with a
requests-alternative.